### PR TITLE
alpine based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de"
 USER root
 
 ENV BUILD_PACKAGES="\
+      gawk \
       gcc \
       git \
       maven \
@@ -15,9 +16,11 @@ ENV BUILD_PACKAGES="\
       "
 
 ENV PACKAGES="\
-      openjdk11 \
+      fontconfig \
+      openjdk8 \
       python3 \
       vim \
+      ttf-dejavu \
       zip \
       "
 
@@ -27,11 +30,12 @@ RUN echo "Install dependencies and tools";\
     apk add --no-cache $PACKAGES; \
     echo "Install step done"
 
-
 ENV LC_ALL "en_US.UTF-8"
 
 # install SNAPPY
-ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk"
-ENV PATH $PATH:/usr/lib/jvm/java-11-openjdk/bin
+ENV JAVA_HOME "/usr/lib/jvm/java-1.8-openjdk"
+# SNAP wants the current folder '.' included in LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
+
 COPY snap /src/snap
 RUN sh /src/snap/install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,37 @@
-FROM mundialis/grass-py3-pdal:stable-alpine
+FROM alpine:edge
 
 LABEL authors="Carmen Tawalika,Markus Neteler"
 LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de"
 
-ARG SOURCE_GIT_URL=https://github.com
-ARG SOURCE_GIT_REMOTE=mundialis
-ARG SOURCE_GIT_REPO=esa_snap_docker
-# can be "tags" (for tag) or "heads" (for) branch
-ARG SOURCE_GIT_TYPE=heads
-# can be a tag name or branch name
-ARG SOURCE_GIT_REF=master
-
 USER root
 
 ENV BUILD_PACKAGES="\
+      gcc \
+      git \
       maven \
-      openjdk8"
+      musl-dev \
+      python3-dev \
+      wget \
+      "
 
 ENV PACKAGES="\
-      git \
-      vim"
+      openjdk11 \
+      python3 \
+      vim \
+      zip \
+      "
 
-WORKDIR /src
-
-# Install minimalistic dependencies and tools
-RUN echo "Install minimalistic dependencies and tools";\
+RUN echo "Install dependencies and tools";\
     apk update; \
-    apk add --no-cache \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-            $PACKAGES; \
-    # Add packages just for the GRASS addon install process
-    apk add --no-cache \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-            --virtual .build-deps $BUILD_PACKAGES; \
-    #
+    apk add --no-cache --virtual .build-deps $BUILD_PACKAGES; \
+    apk add --no-cache $PACKAGES; \
     echo "Install step done"
+
 
 ENV LC_ALL "en_US.UTF-8"
 
 # install SNAPPY
-ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
-ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
+ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk"
+ENV PATH $PATH:/usr/lib/jvm/java-11-openjdk/bin
 COPY snap /src/snap
 RUN sh /src/snap/install.sh
-
-# Reduce the image size
-RUN rm -rf /src/*; \
-    # remove build dependencies and any leftover apk cache
-    apk del --no-cache --purge .build-deps; \
-    rm -rf /var/cache/apk/*; \
-    rm -rf /root/.cache
-
-ENTRYPOINT ["/bin/bash"]
-#CMD ["/src/start.sh"]
-

--- a/README.md
+++ b/README.md
@@ -8,4 +8,41 @@ https://hub.docker.com/r/mundialis/esa-snap
 
 ## Background info
 
-This docker image is based on mundialis/grass-py3-pdal
+This docker image is based on alpine
+
+* the original installer provided by ESA ships its own oracle java
+* alpine is based on musl libc and busybox. As oracle java depends on glibc, it
+  doesn't work smoothely. With https://github.com/sgerrand/alpine-pkg-glibc this
+  can be workarounded to a certain way but in our case not sufficient (conflicting dependencies).
+* Current SNAP Version (7.0.2) is recommended to be run with JAVA 8.
+  From Version 8, oracle java > 8 and openjdk in general will be supported officially (https://forum.step.esa.int/t/problems-running-tests-in-intellij/9350/8)
+
+
+## Dev stuff
+
+Alternatively, a build approch was tried out. Kept here if needed further.
+As stable version 7.0.2 needs maven 3.6.0 (while alpine offers 3.6.3), so SNAP 8 was built for testing.
+
+```
+
+FROM alpine:edge
+
+<!-- ARG SNAP_ENGINE_TAG=7.0.2 -->
+ENV JAVA_HOME "/usr/lib/jvm/java-1.8-openjdk"
+
+RUN apk add git openjdk8 maven
+RUN git clone https://github.com/senbox-org/snap-engine.git /src/snap/snap-engine
+WORKDIR /src/snap/snap-engine
+<!-- RUN git checkout $SNAP_ENGINE_TAG -->
+RUN sed -i 's+<module>snap-classification</module>+<!--<module>snap-classification</module>-->+g' pom.xml
+RUN mvn clean install -DskipTests
+
+WORKDIR /src/snap/s1tbx
+git clone https://github.com/senbox-org/s1tbx.git /src/snap/s1tbx
+cd s1tbx
+mvn clean install
+
+WORKDIR /src/snap/snap-enginge
+java -cp snap-runtime/target/snap-runtime.jar org.esa.snap.runtime.BundleCreator ../snap.zip "/src/snap/snap-engine" "/src/snap/s1tbx"
+
+```

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -2,16 +2,13 @@
 
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539778/Install+SNAP+on+the+command+line
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
-
 # http://step.esa.int/main/download/snap-download/
-SNAPVER=7
 
-# set JAVA_HOME (done in Docker as well)
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+SNAPVER=7
 
 # install module 'jpy' (A bi-directional Python-Java bridge)
 git clone https://github.com/bcdev/jpy.git /src/snap/jpy
-pip3 install wheel
+pip3 install --upgrade pip wheel
 (cd /src/snap/jpy && python3 setup.py bdist_wheel)
 # hack because ./snappy-conf will create this dir but also needs *.whl files...
 mkdir -p /root/.snap/snap-python/snappy
@@ -20,7 +17,19 @@ cp /src/snap/jpy/dist/*.whl "/root/.snap/snap-python/snappy"
 # install and update snap
 wget -q -O /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh \
   "http://step.esa.int/downloads/${SNAPVER}.0/installers/esa-snap_all_unix_${SNAPVER}_0.sh"
+
+# hacks to make it run on alpine
+sed -i 's+ bin/unpack200+ $JAVA_HOME/bin/unpack200+g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
+# more hacks to use system java and not oracle (included in installer).
+# Oracle JAVA is not supported with alpine due to missing glibc.
+sed -i 's+$INSTALL4J_JAVA_PREFIX "$app_java_home/bin/java"+$INSTALL4J_JAVA_PREFIX java+g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
+sed -i 's+-Dinstall4j.jvmDir="$app_java_home"+-Dinstall4j.jvmDir=$JAVA_HOME/jre+g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
+sed -i 's+-Djava.ext.dirs="$app_java_home/lib/ext:$app_java_home/jre/lib/ext"++g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
+sed -i 's+-classpath "$local_classpath"+-classpath "$local_classpath:$app_java_home/lib/ext:$app_java_home/jre/lib/ext"+g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
 sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.varfile
+
+# one more hack to keep using system java
+sed -i 's+jdkhome="./jre"+jdkhome="$JAVA_HOME"+g' /usr/local/snap/etc/snap.conf
 /usr/local/snap/bin/snap --nosplash --nogui --modules --update-all
 
 # create snappy and python binding with snappy
@@ -32,3 +41,7 @@ sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.va
 
 # cleanup installer
 rm -f /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
+
+################################################################################
+# keep for debugging
+# export INSTALL4J_KEEP_TEMP=yes

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -1,4 +1,4 @@
-# /bin/sh
+#!/bin/sh
 
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539778/Install+SNAP+on+the+command+line
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
@@ -7,7 +7,7 @@
 SNAPVER=7
 
 # set JAVA_HOME (done in Docker as well)
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
 # install module 'jpy' (A bi-directional Python-Java bridge)
 git clone https://github.com/bcdev/jpy.git /src/snap/jpy
@@ -29,3 +29,6 @@ sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.va
 
 # test
 /usr/bin/python3 -c 'from snappy import ProductIO'
+
+# cleanup installer
+rm -f /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh

--- a/snap/response.varfile
+++ b/snap/response.varfile
@@ -1,4 +1,4 @@
-# install4j response file for ESA SNAP 6.0
+# install4j response file for ESA SNAP 7.0
 deleteSnapDir=DESKTOP
 executeLauncherWithPythonAction$Boolean=true
 forcePython$Boolean=true


### PR DESCRIPTION
Draft version. Open issue:

```
docker build .
...
Removing intermediate container 19f4d880f266
 ---> 984086b09802
Step 15/20 : ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ---> Running in 001cc457cccd
Removing intermediate container 001cc457cccd
 ---> ffce88c5d4d0
Step 16/20 : ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 ---> Running in 51ba59b6c836
Removing intermediate container 51ba59b6c836
 ---> 68d7c69a189a
Step 17/20 : COPY snap /src/snap
 ---> 57ed4bca7a62
Step 18/20 : RUN sh /src/snap/install.sh
 ---> Running in 813ccc336e09
Cloning into '/src/snap/jpy'...
Collecting wheel
  Downloading https://files.pythonhosted.org/packages/00/83/b4a77d044e78ad1a45610eb88f745be2fd2c6d658f9798a15e384b7d57c9/wheel-0.33.6-py2.py3-none-any.whl
Installing collected packages: wheel
Successfully installed wheel-0.33.6
The JAVA_HOME environment variable is not defined correctly
This environment variable is needed to run this program
NB: JAVA_HOME should point to a JDK not a JRE
Error: environment variable "JAVA_HOME" must be set to a JDK (>= v1.7) installation directory
Note that you can use non-standard global option [--maven] to force a Java Maven build for the jpy Java API
cp: can't stat '/src/snap/jpy/dist/*.whl': No such file or directory
...
```

I am unsure how to fix the JAVA_HOME path and related...