### PR TITLE
log snap version and jvm size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,3 +48,4 @@ COPY --from=build /root/.snap /root/.snap
 COPY --from=build /usr/local/snap /usr/local/snap
 RUN (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 RUN /usr/bin/python3 -c 'from snappy import ProductIO'
+RUN /usr/bin/python3 /root/.snap/about.py

--- a/snap/about.py
+++ b/snap/about.py
@@ -1,0 +1,14 @@
+#!/bin/python
+
+from snappy import ProductIO
+import jpy
+
+# JAVA VM size
+Runtime = jpy.get_type('java.lang.Runtime')
+heap_size = Runtime.getRuntime().maxMemory() / (1024*1024)
+print('JVM size:',heap_size, "MB")
+
+# ESA SNAP version
+vc = jpy.get_type('org.esa.snap.core.util.VersionChecker')
+version = vc.getInstance().getLocalVersion().toString()
+print('SNAP VERSION:',version)

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -44,6 +44,12 @@ rm -rf /usr/local/snap/jre
 
 # test
 /usr/bin/python3 -c 'from snappy import ProductIO'
+if [ -f /src/snap/about.py ]
+then
+    /usr/bin/python3 /src/snap/about.py
+    cp /src/snap/about.py /root/.snap/
+fi
+
 
 # cleanup installer
 rm -f /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh


### PR DESCRIPTION
With this PR, a python script is added to log additional information during build:

```
Step 20/20 : RUN /usr/bin/python3 /root/.snap/about.py
 ---> Running in faae92e71785
INFO: org.esa.snap.core.gpf.operators.tooladapter.ToolAdapterIO: Initializing external tool adapters
INFO: org.esa.snap.core.util.EngineVersionCheckActivator: Please check regularly for new updates for the best SNAP experience.
JVM size: 9102.5 MB
SNAP VERSION: 7.0
```

This RUN statement can also be run in Images which copy from esa-snap via multistage.
