### PR TITLE
Use fixed version for openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
-FROM alpine:edge as build
+FROM alpine:3.11 as base
+
+ARG OPENJDK_VERSION=8.232.09-r0
+ARG OPENJDK_PKGS_URL=https://github.com/mmacata/alpine-openjdk8/releases/download/$OPENJDK_VERSION
+
+RUN apk add curl
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-$OPENJDK_VERSION.apk > openjdk8-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-$OPENJDK_VERSION.apk > openjdk8-jre-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-base-$OPENJDK_VERSION.apk > openjdk8-jre-base-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-lib-$OPENJDK_VERSION.apk > openjdk8-jre-lib-$OPENJDK_VERSION.apk
+
+RUN apk add --allow-untrusted \
+    openjdk8-jre-lib-$OPENJDK_VERSION.apk \
+    openjdk8-$OPENJDK_VERSION.apk \
+    openjdk8-jre-base-$OPENJDK_VERSION.apk \
+    openjdk8-jre-$OPENJDK_VERSION.apk
+
+
+FROM base as build
 
 LABEL authors="Carmen Tawalika,Markus Neteler"
 LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de"
@@ -40,7 +58,7 @@ COPY snap /src/snap
 RUN sh /src/snap/install.sh
 
 
-FROM alpine:edge
+FROM base as snappy
 
 RUN apk add openjdk8 python3
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -10,8 +10,9 @@ java_max_mem=10G
 
 # install module 'jpy' (A bi-directional Python-Java bridge)
 git clone https://github.com/bcdev/jpy.git /src/snap/jpy
+python3 -m ensurepip
 pip3 install --upgrade pip wheel
-(cd /src/snap/jpy && python3 setup.py bdist_wheel)
+(cd /src/snap/jpy && python3 setup.py build maven bdist_wheel)
 # hack because ./snappy-conf will create this dir but also needs *.whl files...
 mkdir -p /root/.snap/snap-python/snappy
 cp /src/snap/jpy/dist/*.whl "/root/.snap/snap-python/snappy"


### PR DESCRIPTION
As with openjdk8-8.242 the build was broken (see https://github.com/mmacata/alpine-openjdk8/blob/master/README.md), this PR suggests to use a fixed version.
The image is now based on `alpine:3.11` instead of `alpine:edge` to have less frequent version updates which might break things. (The new openjdk version was also introduced into 3.11 nevertheless.)