### PR TITLE
alpine version 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as base
+FROM alpine:3.12 as base
 
 ARG OPENJDK_VERSION=8.232.09-r0
 ARG OPENJDK_PKGS_URL=https://github.com/mmacata/alpine-openjdk8/releases/download/$OPENJDK_VERSION


### PR DESCRIPTION
There is a new alpine version 3.12 (https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases).