### PR TITLE
ESA SNAP 8 docker image based on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESA SNAP 8 docker image
 
-Docker image of ESA Sentinel Application Platform (SNAP) from http://step.esa.int/main/toolboxes/snap/
+Ubuntu based docker image of ESA Sentinel Application Platform (SNAP) from http://step.esa.int/main/toolboxes/snap/
 
 The related docker image created and available for download from here:
 
@@ -8,41 +8,4 @@ https://hub.docker.com/r/mundialis/esa-snap
 
 ## Background info
 
-This docker image is based on alpine
-
-* the original installer provided by ESA ships its own oracle java
-* alpine is based on musl libc and busybox. As oracle java depends on glibc, it
-  doesn't work smoothely. With https://github.com/sgerrand/alpine-pkg-glibc this
-  can be workarounded to a certain way but in our case not sufficient (conflicting dependencies).
-* Current SNAP Version (7.0.2) is recommended to be run with JAVA 8.
-  From Version 8, oracle java > 8 and openjdk in general will be supported officially (https://forum.step.esa.int/t/problems-running-tests-in-intellij/9350/8)
-
-
-## Dev stuff
-
-Alternatively, a build approch was tried out. Kept here if needed further.
-As stable version 7.0.2 needs maven 3.6.0 (while alpine offers 3.6.3), so SNAP 8 was built for testing.
-
-```
-
-FROM alpine:edge
-
-<!-- ARG SNAP_ENGINE_TAG=7.0.2 -->
-ENV JAVA_HOME "/usr/lib/jvm/java-1.8-openjdk"
-
-RUN apk add git openjdk8 maven
-RUN git clone https://github.com/senbox-org/snap-engine.git /src/snap/snap-engine
-WORKDIR /src/snap/snap-engine
-<!-- RUN git checkout $SNAP_ENGINE_TAG -->
-RUN sed -i 's+<module>snap-classification</module>+<!--<module>snap-classification</module>-->+g' pom.xml
-RUN mvn clean install -DskipTests
-
-WORKDIR /src/snap/s1tbx
-git clone https://github.com/senbox-org/s1tbx.git /src/snap/s1tbx
-cd s1tbx
-mvn clean install
-
-WORKDIR /src/snap/snap-enginge
-java -cp snap-runtime/target/snap-runtime.jar org.esa.snap.runtime.BundleCreator ../snap.zip "/src/snap/snap-engine" "/src/snap/s1tbx"
-
-```
+This docker image is based on Ubuntu

--- a/snap/response.varfile
+++ b/snap/response.varfile
@@ -1,4 +1,4 @@
-# install4j response file for ESA SNAP 7.0
+# install4j response file for ESA SNAP 8.0
 deleteSnapDir=DESKTOP
 executeLauncherWithPythonAction$Boolean=true
 forcePython$Boolean=true


### PR DESCRIPTION
Since SNAP still needs Python 3.6 we have to use ubuntu:18.04
(source: https://forum.step.esa.int/t/modulenotfounderror-no-module-named-jpyutil/25785/2)

Addresses #8 

Note that this additional Dockerfile is meant to stay in a separate branch, in parallel to the existing Alpine docker image.