### PR TITLE
Upgrade to SNAP 9.0.0 (#16)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,12 +63,14 @@ RUN sh /src/snap/install.sh
 
 FROM base as snappy
 
-RUN apk add openjdk8 python3 ttf-dejavu
+RUN apk add python3 ttf-dejavu
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
+ENV JAVA_HOME "/usr/lib/jvm/java-1.8-openjdk"
 COPY --from=build /root/.snap /root/.snap
 COPY --from=build /usr/local/snap /usr/local/snap
+COPY --from=build /src/snap /root/snap
 RUN (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 # update SNAP from Web, requires font
-RUN /usr/local/snap/bin/snap --nosplash --nogui --modules --update-all
+RUN sh /root/snap/update.sh
 RUN /usr/bin/python3 -c 'from snappy import ProductIO'
 RUN /usr/bin/python3 /root/.snap/about.py

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -4,7 +4,7 @@
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
 # SNAP latest Version: http://step.esa.int/main/download/snap-download/
 
-SNAPVER=8
+SNAPVER=9
 # avoid NullPointer crash during S-1 processing
 java_max_mem=10G
 
@@ -19,7 +19,7 @@ cp /src/snap/jpy/dist/*.whl "/root/.snap/snap-python/snappy"
 
 # install and update snap
 wget -q -O /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh \
-  "http://step.esa.int/downloads/${SNAPVER}.0/installers/esa-snap_all_unix_${SNAPVER}_0.sh"
+  "http://step.esa.int/downloads/${SNAPVER}.0/installers/esa-snap_all_unix_${SNAPVER}_0_0.sh"
 
 # hacks to make it run on alpine
 sed -i 's+ bin/unpack200+ $JAVA_HOME/bin/unpack200+g' /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh
@@ -38,7 +38,19 @@ sed -i 's+jdkhome="./jre"+jdkhome="$JAVA_HOME"+g' /usr/local/snap/etc/snap.conf
 rm -rf /usr/local/snap/jre
 
 # create snappy and python binding with snappy
-/usr/local/snap/bin/snappy-conf /usr/bin/python3
+
+
+/usr/local/snap/bin/snappy-conf /usr/bin/python3 2>&1 | while read -r line; do
+    echo "$line"
+    if [ "$line" = "or copy the 'snappy' module into your Python's 'site-packages' directory." ]
+    then
+      echo "Ok"
+      sleep 2
+      echo "Stopping Now"
+      pkill -TERM -f java
+    fi
+done
+
 (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 
 # increase the JAVA VM size to avoid NullPointer exception in Snappy during S-1 processing

--- a/snap/update.sh
+++ b/snap/update.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+## From here https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
+
+/usr/local/snap/bin/snap --nosplash --nogui --modules --update-all 2>&1 | while read -r line; do
+    echo "$line"
+    if [ "$line" = "updates=0" ]
+    then
+      echo "Ok"
+      sleep 2
+      echo "Stopping Now"
+      pkill -TERM -f java
+    fi
+done


### PR DESCRIPTION
Hello, I upgraded SNAP to 9.0.0
as in this ticket #16 

There were a few changes necessary
1. `/usr/local/snap/bin/snap --nosplash --nogui --modules --update-all` https://github.com/mundialis/esa-snap/compare/master...thierryweo:esa-snap:master#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L72 does not terminate. Fix is to write a short shell command to look for a special line and then terminate the process (update.sh)
2. `/usr/local/snap/bin/snappy-conf /usr/bin/python3` command does no terminate so same as in point 1. wait for last line and terminate java process
3. `openjdk8`is not necessay in final Docker image as it is already baked in the `base` image

Test Image is pushed here to test https://hub.docker.com/repository/docker/thierrydoc/esa-snap/general
I am not 100% sure everything is setup correctly:

1. Following message appears
```INFO: org.esa.snap.core.gpf.operators.tooladapter.ToolAdapterIO: Initializing external tool adapters
INFO: org.esa.s2tbx.dataio.gdal.GDALVersion: GDAL not found on system. Internal GDAL 3.2.1 from distribution will be used. (f0)
INFO: org.esa.s2tbx.dataio.gdal.GDALVersion: Internal GDAL 3.2.1 set to be used by SNAP.
Native library load failed.
java.lang.UnsatisfiedLinkError: /root/.snap/auxdata/gdal/gdal-3-2-1/lib/jni/libgdalalljni.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /root/.snap/auxdata/gdal/gdal-3-2-1/lib/jni/libgdal.so)
SEVERE: org.esa.s2tbx.dataio.gdal.GDALLoader: Failed to initialize GDAL native drivers. GDAL readers and writers were disabled.java.lang.reflect.InvocationTargetException
INFO: org.esa.snap.core.util.EngineVersionCheckActivator: Please check regularly for new updates for the best SNAP experience.```


Please let me know if there are problems I will look into them happily
