### PR TITLE
Upgrade to SNAP-9.0.0 for ubuntu (#16)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,14 +47,14 @@ RUN update-alternatives --remove python /usr/bin/python3
 # INFO: org.esa.s2tbx.dataio.gdal.GDALVersion: GDAL not found on system. Internal GDAL 3.0.0 from distribution will be used. (f1)
 
 # path
-RUN echo "export PATH=\$PATH:/usr/local/snap/bin/:/root/.snap/auxdata/gdal/gdal-3-0-0/bin" >> /root/.bashrc
+RUN echo "export PATH=\$PATH:/usr/local/snap/bin/:/root/.snap/auxdata/gdal/gdal-3-2-1/bin" >> /root/.bashrc
 
 # tests
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/50855941/Configure+Python+to+use+the+SNAP-Python+snappy+interface
 RUN (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 RUN /usr/bin/python3 -c 'from snappy import ProductIO'
 RUN /usr/bin/python3 /src/snap/about.py
-RUN /root/.snap/auxdata/gdal/gdal-3-0-0/bin/gdal-config --version
+RUN /root/.snap/auxdata/gdal/gdal-3-2-1/bin/gdal-config --version
 
 # When using SNAP from Python, either do: sys.path.append('/root/.snap/snap-python')
 

--- a/snap/install.sh
+++ b/snap/install.sh
@@ -4,7 +4,7 @@
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
 # http://step.esa.int/main/download/snap-download/
 
-SNAPVER=8
+SNAPVER=9
 # avoid NullPointer crash during S-1 processing
 java_max_mem=10G
 
@@ -21,7 +21,7 @@ cp /src/snap/jpy/dist/*.whl "/root/.snap/snap-python/snappy"
 
 # install and update snap
 wget -q -O /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh \
-  "http://step.esa.int/downloads/${SNAPVER}.0/installers/esa-snap_all_unix_${SNAPVER}_0.sh"
+  "http://step.esa.int/downloads/${SNAPVER}.0/installers/esa-snap_all_unix_${SNAPVER}_0_0.sh"
 sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.varfile
 
 # Current workaround for "commands hang after they are actually executed":  https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
@@ -32,7 +32,17 @@ sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.va
 done
 
 # create snappy and python binding with snappy
-/usr/local/snap/bin/snappy-conf /usr/bin/python3
+/usr/local/snap/bin/snappy-conf /usr/bin/python3 2>&1 | while read -r line; do
+    echo "$line"
+    if [ "$line" = "or copy the 'snappy' module into your Python's 'site-packages' directory." ]
+    then
+      echo "Ok"
+      sleep 2
+      echo "Stopping Now"
+      pkill -TERM -f java
+    fi
+done
+
 (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 
 # increase the JAVA VM size to avoid NullPointer exception in Snappy during S-1 processing


### PR DESCRIPTION
Based on #17 and addressing #16, I updated the Dockerfile for the Ubuntu tag. The main difference is that I included the contents of `snap/update.sh` in `snap/install.sh`. 
I do not get any GDAL error on my side. I tested the image locally by running scripts with snappy and everything seems to work good. 

Do let me know if there is any thing I should look into. 