### PR TITLE
docker: CI update for Ubuntu SNAP image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    branches: [s1tbx]
+
+jobs:
+
+  docker:
+    name: build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Create image and tag names
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: mundialis/esa-snap
+          tags: |
+            type=sha,enable=true,priority=100,prefix=s1tbx-,suffix=,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'ubuntu') }}
+          flavor: |
+            latest=auto
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          pull: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [s1tbx]
+    branches: [ubuntu]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESA SNAP 8 docker image
+# ESA SNAP 9 docker image
 
 Ubuntu based docker image of ESA Sentinel Application Platform (SNAP) from http://step.esa.int/main/toolboxes/snap/
 
@@ -11,6 +11,15 @@ https://hub.docker.com/r/mundialis/esa-snap
 s1tbx |Only s1tbx toolbox| [s1tbx](https://github.com/mundialis/esa-snap/tree/s1tbx)   | Alpine based| 600 MB| `docker pull mundialis/esa-snap:s1tbx`
 latest|All SNAP toolboxes| [master](https://github.com/mundialis/esa-snap/)            | Alpine based|1.15 GB| `docker pull mundialis/esa-snap:latest`
 ubuntu|All SNAP toolboxes| [ubuntu](https://github.com/mundialis/esa-snap/tree/ubuntu) | Ubuntu based|   2 GB| `docker pull mundialis/esa-snap:ubuntu`
+
+
+## Installation
+
+Pull the Ubuntu Linux based image (all SNAP toolboxes included):
+
+```
+docker pull mundialis/esa-snap:ubuntu
+```
 
 ## Background info
 

--- a/snap/response.varfile
+++ b/snap/response.varfile
@@ -1,4 +1,4 @@
-# install4j response file for ESA SNAP 8.0
+# install4j response file for ESA SNAP 9.0
 deleteSnapDir=DESKTOP
 executeLauncherWithPythonAction$Boolean=true
 forcePython$Boolean=true


### PR DESCRIPTION
Added workflow to automatically generate Ubuntu-based docker image.

Also update GH action versions.